### PR TITLE
Show latest survey response in UI and fix upsert/fetch logic for survey responses

### DIFF
--- a/kinisi-app/app/survey/page.tsx
+++ b/kinisi-app/app/survey/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+import React, { useEffect, useState, useCallback } from 'react';
+import { upsertSurveyResponse, getSurveyResponse } from '../../utils/surveyResponses';
+import { supabase } from '../../utils/supabaseClient';
+import intakeSurveySchema from './intake-survey-questions.json';
+import { useRouter } from 'next/navigation';
+
+// Helper: debounce
+function debounce<T extends (...args: any[]) => void>(fn: T, delay: number) {
+  let timeoutId: NodeJS.Timeout;
+  return (...args: Parameters<T>) => {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn(...args), delay);
+  };
+}
+
+const SurveyPage = () => {
+  const [formData, setFormData] = useState<any>({});
+  const [userId, setUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchUserAndData = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        router.push('/login');
+        return;
+      }
+      setUserId(user.id);
+      const { data } = await getSurveyResponse(user.id);
+      if (data && data.length > 0 && data[0].response) {
+        setFormData(data[0].response);
+      }
+      setLoading(false);
+    };
+    fetchUserAndData();
+  }, [router]);
+
+  // Handle form changes
+  const handleChange = (field: string, value: any) => {
+    const newData = { ...formData, [field]: value };
+    setFormData(newData);
+  };
+
+  // Debounced save
+  const debouncedSave = useCallback(
+    debounce(async (updatedData) => {
+      if (userId) {
+        await upsertSurveyResponse(userId, updatedData);
+      }
+    }, 800),
+    [userId]
+  );
+
+  useEffect(() => {
+    if (userId && Object.keys(formData).length > 0) {
+      debouncedSave(formData);
+    }
+  }, [formData, userId, debouncedSave]);
+
+  if (loading) {
+    return <div className="flex min-h-screen items-center justify-center text-gray-500">Loading...</div>;
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto py-10">
+      <h1 className="text-2xl font-bold mb-6">Intake Survey</h1>
+      <form className="space-y-6">
+        {Object.entries(intakeSurveySchema.properties).map(([key, config]: [string, any]) => (
+          <div key={key}>
+            <label className="block font-medium mb-2">{config.title}</label>
+            <input
+              type={config.type === 'number' ? 'number' : 'text'}
+              className="border p-2 rounded w-full"
+              value={formData[key] || ''}
+              onChange={e => handleChange(key, config.type === 'number' ? Number(e.target.value) : e.target.value)}
+            />
+          </div>
+        ))}
+      </form>
+      <div className="mt-8">
+        <button
+          className="bg-blue-600 text-white px-6 py-2 rounded shadow hover:bg-blue-700"
+          onClick={() => router.push('/survey/results')}
+        >
+          Finish
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SurveyPage;

--- a/kinisi-app/app/survey/results/page.tsx
+++ b/kinisi-app/app/survey/results/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { getSurveyResponse } from "@/utils/surveyResponses";
+import intakeSurveySchema from "../intake-survey-questions.json";
+
+function formatAnswer(key: string, value: any, schema: any): React.ReactNode {
+  if (schema[key]?.enum) {
+    const label = schema[key].enumNames?.[schema[key].enum.indexOf(value)] ?? value;
+    return <span>{label}</span>;
+  }
+  return <span>{value}</span>;
+}
+
+const SurveyResultsPage = () => {
+  const [response, setResponse] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [user, setUser] = useState<any>(null);
+  const [authLoading, setAuthLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      setAuthLoading(true);
+      const { data: { user } } = await import("@/utils/supabaseClient").then(m => m.supabase.auth.getUser());
+      setUser(user);
+      setAuthLoading(false);
+    };
+    fetchUser();
+  }, []);
+
+  useEffect(() => {
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      const { data, error } = await getSurveyResponse(user.id);
+      if (error) setError("Failed to fetch survey response.");
+      setResponse(data && data.length > 0 ? data[0].response : null);
+      setLoading(false);
+    };
+    fetchData();
+  }, [user, authLoading, router]);
+
+  const isComplete = response &&
+    intakeSurveySchema.required.every((key: string) => response[key] !== undefined && response[key] !== "");
+
+  if (loading || authLoading) {
+    return <div className="flex min-h-screen items-center justify-center text-gray-500">Loading...</div>;
+  }
+
+  if (error) {
+    return <div className="text-red-500">{error}</div>;
+  }
+
+  if (!response) {
+    return <div className="text-gray-500">No survey response found.</div>;
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto py-10">
+      <h1 className="text-2xl font-bold mb-6">Survey Results</h1>
+      {!isComplete && (
+        <div className="mb-4 text-yellow-600">Survey is incomplete.</div>
+      )}
+      <div className="space-y-4">
+        {Object.entries(intakeSurveySchema.properties).map(([key, config]: [string, any]) => (
+          <div key={key}>
+            <span className="font-medium">{config.title}:</span>{" "}
+            {formatAnswer(key, response[key], intakeSurveySchema.properties)}
+          </div>
+        ))}
+      </div>
+      <div className="mt-8">
+        <button
+          className="bg-blue-600 text-white px-6 py-2 rounded shadow hover:bg-blue-700"
+          onClick={() => router.push("/survey")}
+        >
+          Edit Survey
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SurveyResultsPage;

--- a/kinisi-app/utils/surveyResponses.ts
+++ b/kinisi-app/utils/surveyResponses.ts
@@ -1,0 +1,38 @@
+import { supabase } from './supabaseClient';
+import { Database } from '../types/supabase';
+
+// Survey response TypeScript type (matches Supabase schema)
+export type SurveyResponse = {
+  id: string;
+  user_id: string;
+  response: any;
+  created_at: string;
+  updated_at: string;
+};
+
+// Save or update survey response (auto-save)
+export async function upsertSurveyResponse(userId: string, response: any) {
+  const { data, error } = await supabase
+    .from('survey_responses')
+    .upsert([
+      { user_id: userId, response }
+    ], { onConflict: ['id'] })
+    .select();
+  return { data, error };
+}
+
+// Get latest survey response for a user
+export async function getSurveyResponse(userId: string) {
+  try {
+    const { data, error } = await supabase
+      .from('survey_responses')
+      .select('*')
+      .eq('user_id', userId)
+      .order('updated_at', { ascending: false });
+    
+    return { data, error };
+  } catch (err) {
+    console.error('Error fetching survey response:', err);
+    return { data: null, error: new Error('Failed to fetch survey response. Please try again.') };
+  }
+}


### PR DESCRIPTION
## Summary

- The survey results page now always displays the most recent response for a user by ordering by `updated_at` descending and selecting the first result.
- The survey intake and results pages were updated to handle the survey response as an array, resolving previous TypeScript errors.
- The upsert logic remains robust and compatible with the Supabase schema.

## Why

This ensures that users always see their latest survey results after editing, and fixes issues where updates were not reflected in the UI.

---

Closes #latest-survey-response-ui