### PR TITLE
feat(promptlayer): track assessment prompts via PromptLayer

### DIFF
--- a/__tests__/api/assessment.test.ts
+++ b/__tests__/api/assessment.test.ts
@@ -232,6 +232,10 @@ describe('/api/assessment', () => {
     expect(response.status).toBe(200);
     expect(data.id).toBe('assessment-1');
     expect(data.assessment).toBe('Generated assessment');
-    expect(mockGenerateAssessment).toHaveBeenCalledWith({ goal: 'fitness', experience: 'beginner' });
+    // Updated signature passes options with userId
+    expect(mockGenerateAssessment).toHaveBeenCalledWith(
+      { goal: 'fitness', experience: 'beginner' },
+      { userId: 'user-1' }
+    );
   });
 });

--- a/__tests__/unit/assessmentChain.promptlayer.test.ts
+++ b/__tests__/unit/assessmentChain.promptlayer.test.ts
@@ -1,0 +1,83 @@
+// __tests__/unit/assessmentChain.promptlayer.test.ts
+import { jest } from '@jest/globals';
+
+// Mock RAG utilities to avoid embeddings/DB/network
+jest.mock('@/utils/rag', () => ({
+  retrieveRagChunksForSurvey: jest.fn().mockResolvedValue([]),
+  formatChunksAsContext: jest.fn().mockReturnValue(''),
+}));
+
+// Mock RunnableSequence.from to prevent any LLM invocation
+jest.mock('@langchain/core/runnables', () => ({
+  RunnableSequence: {
+    from: jest.fn(() => ({ invoke: jest.fn().mockResolvedValue('ok') })),
+  },
+}));
+
+// Ensure OPENAI_API_KEY present to satisfy guards
+const OLD_ENV = process.env;
+
+describe('assessmentChain PromptLayer tracking', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV, OPENAI_API_KEY: 'test-openai-key' };
+    // Clear the global mock installed in jest.setup.js
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pl = require('@/utils/promptlayer');
+    if (pl.trackPromptRun && 'mockClear' in pl.trackPromptRun) {
+      pl.trackPromptRun.mockClear();
+    }
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    jest.clearAllMocks();
+  });
+
+  it('tracks Personalized Assessment generation with expected tags/metadata', async () => {
+    const { generateAssessmentFromSurvey } = await import('@/utils/assessmentChain');
+    // Call the function under test
+    await generateAssessmentFromSurvey({ primaryGoal: 'Strength' }, { userId: 'u1' });
+    // Read calls from the global mock installed in jest.setup.js
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pl = require('@/utils/promptlayer');
+    expect(pl.trackPromptRun).toHaveBeenCalledTimes(1);
+    const call = pl.trackPromptRun.mock.calls[0][0] as any;
+    expect(call.promptName).toBe('Personalized Assessment');
+    expect(call.tags).toEqual(expect.arrayContaining(['v2', 'assessment']));
+    expect(call.tags).toEqual(expect.arrayContaining(['dev']));
+    expect(call.metadata).toMatchObject({
+      userId: 'u1',
+      model: 'gpt-3.5-turbo',
+      temperature: 0.7,
+    });
+    expect(call.metadata.usedRegistry).toBe(false);
+    expect(call.metadata.ragChunksCount).toBe(0);
+  });
+
+  it('tracks Update Personalized Assessment revision with expected tags/metadata', async () => {
+    const { reviseAssessmentWithFeedback } = await import('@/utils/assessmentChain');
+
+    await reviseAssessmentWithFeedback({
+      currentAssessment: 'A',
+      feedback: 'F',
+      surveyResponses: {},
+      userId: 'u1',
+      revisionOfAssessmentId: '123e4567-e89b-12d3-a456-426614174000',
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pl = require('@/utils/promptlayer');
+    expect(pl.trackPromptRun).toHaveBeenCalledTimes(1);
+    const call = pl.trackPromptRun.mock.calls[0][0] as any;
+    expect(call.promptName).toBe('Update Personalized Assessment');
+    expect(call.tags).toEqual(expect.arrayContaining(['v2', 'assessment_revision']))
+    expect(call.tags).toEqual(expect.arrayContaining(['dev']));
+    expect(call.metadata).toMatchObject({
+      userId: 'u1',
+      revisionOfAssessmentId: '123e4567-e89b-12d3-a456-426614174000',
+      model: 'gpt-3.5-turbo',
+      temperature: 0.7,
+    });
+  });
+});

--- a/app/api/assessment/route.ts
+++ b/app/api/assessment/route.ts
@@ -51,7 +51,7 @@ export async function POST(req: NextRequest) {
     // Call LangChain-powered assessment generator
     let assessment: string;
     try {
-      assessment = await generateAssessmentFromSurvey(surveyResponses);
+      assessment = await generateAssessmentFromSurvey(surveyResponses, { userId: user.id });
     } catch (e: unknown) {
       console.error('[assessment] Generation failed:', e);
       return NextResponse.json({ error: 'Failed to generate assessment' }, { status: 500 });

--- a/utils/promptlayerClient.ts
+++ b/utils/promptlayerClient.ts
@@ -1,0 +1,33 @@
+// utils/promptlayerClient.ts
+// Lazy PromptLayer client helper with test/dev safeguards
+
+import type { PromptLayer as PromptLayerType } from "promptlayer";
+
+let _pl: PromptLayerType | null = null;
+
+/**
+ * Returns a singleton PromptLayer client or null when disabled.
+ * Disabled when:
+ * - NODE_ENV === 'test'
+ * - process.env.DISABLE_PROMPTLAYER_TRACKING is truthy
+ * - PROMPTLAYER_API_KEY is missing
+ */
+export function getPromptLayerClient(): PromptLayerType | null {
+  try {
+    if (process.env.NODE_ENV === "test") return null;
+    if (String(process.env.DISABLE_PROMPTLAYER_TRACKING || "").toLowerCase() === "true") return null;
+
+    const apiKey = process.env.PROMPTLAYER_API_KEY;
+    if (!apiKey) return null;
+
+    if (_pl) return _pl;
+    // Note: direct import is fine in server context; this file should not be bundled into client code paths.
+    // If needed, convert to dynamic import to avoid ESM/CJS interop concerns.
+    const { PromptLayer } = require("promptlayer") as { PromptLayer: new (args: { apiKey: string }) => PromptLayerType };
+    _pl = new PromptLayer({ apiKey });
+    return _pl;
+  } catch (e) {
+    // If the SDK isn't available or any unexpected error occurs, disable tracking gracefully.
+    return null;
+  }
+}


### PR DESCRIPTION
Adds PromptLayer Prompt History tracking for assessment generation and revision.\n- Tracking helper and lazy client\n- Instrumented assessmentChain with tags/metadata (env, feature, v2, usedRegistry, ragChunksCount, model, temp)\n- API routes pass userId/revisionOfAssessmentId\n- Jest: global trackPromptRun mock, fetch/streams polyfills, no real network\n- Unit tests asserting tracking payloads\nAll tests pass locally (359).