### PR TITLE
feat/issue 166 promptlayer append revisions

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,32 +1,34 @@
 # PromptLayer “Prompt History” Tracking — Implementation Plan
 
 ## Overview
-- Non-blocking PromptLayer tracking for Assessment and Revision prompts, preserving existing LangChain execution and Prompt Registry fetch behavior.
-- Aligned with [DEVELOPER_WORKFLOW.md](cci:7://file:///Users/jacobbutler/Documents/GitHub/Kinisi/DEVELOPER_WORKFLOW.md:0:0-0:0):
+- Non-blocking PromptLayer tracking for Assessment and Revision prompts at call sites, preserving existing LangChain execution and Prompt Registry fetch behavior.
+- Aligned with [DEVELOPER_WORKFLOW.md](DEVELOPER_WORKFLOW.md):
   - Tests isolate external services; all real network calls blocked.
-  - Next.js API route testing uses global mocks in [jest.setup.js](cci:7://file:///Users/jacobbutler/Documents/GitHub/Kinisi/jest.setup.js:0:0-0:0).
-  - Build-only typecheck via [tsconfig.build.json](cci:1://file:///Users/jacobbutler/Documents/GitHub/Kinisi/__tests__/integration/api/program-revise-api.test.ts:121:18-121:44).
+  - Next.js API route testing uses global mocks in [jest.setup.js](jest.setup.js).
+  - Build-only typecheck via [tsconfig.build.json](tsconfig.build.json).
   - Pre-PR verification: `npm run lint`, `npm test`, `npm run typecheck`, `npm run build`.
 
 ## Environment
 - `PROMPTLAYER_API_KEY` in staging/prod.
 - Optional: `DISABLE_PROMPTLAYER_TRACKING=true` to force no-op in dev.
+- Optional: `PROMPTLAYER_FETCH_TIMEOUT_MS` (default `3000`) to bound registry calls.
+- Server code uses only `OPENAI_API_KEY` (no fallback to `NEXT_PUBLIC_OPENAI_API_KEY`).
 
 ## Global checklist
 - [x] Create feature branch `feat/promptlayer-tracking`
-- [x] Add [utils/promptlayerClient.ts](cci:7://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/promptlayerClient.ts:0:0-0:0) (lazy client, test env no-op)
-- [x] Append [trackPromptRun()](cci:1://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/promptlayer.ts:71:0-100:1) helper to [utils/promptlayer.ts](cci:7://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/promptlayer.ts:0:0-0:0) with safe try/catch
-- [x] Mock [trackPromptRun](cci:1://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/promptlayer.ts:71:0-100:1) in [jest.setup.js](cci:7://file:///Users/jacobbutler/Documents/GitHub/Kinisi/jest.setup.js:0:0-0:0) (no-op but assertable)
-- [x] Instrument [generateAssessmentFromSurvey()](cci:1://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/assessmentChain.ts:82:0-178:1) with tags/metadata (`usedRegistry`, `ragChunksCount`)
-- [x] Instrument [reviseAssessmentWithFeedback()](cci:1://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/assessmentChain.ts:181:0-267:1) with tags/metadata (`revisionOfAssessmentId`)
+- [x] Add [utils/promptlayerClient.ts](utils/promptlayerClient.ts) (lazy client, test env no-op)
+- [x] Append `trackPromptRun()` helper to [utils/promptlayer.ts](utils/promptlayer.ts) with safe try/catch
+- [x] Mock `trackPromptRun` in [jest.setup.js](jest.setup.js) (no-op but assertable)
+- [x] Instrument [generateAssessmentFromSurvey()](utils/assessmentChain.ts) with tags/metadata (`usedRegistry`, `ragChunksCount`)
+- [x] Instrument [reviseAssessmentWithFeedback()](utils/assessmentChain.ts) with tags/metadata (`revisionOfAssessmentId`)
 - [x] Wire `userId` (and `revisionOfAssessmentId`) from API routes into `assessmentChain` calls
-- [ ] Add unit tests asserting tracking payloads
-- [ ] Ensure no real network calls in tests; registry fetch continues to fallback under blocked fetch
-- [ ] Optional docs update in [DEVELOPER_WORKFLOW.md](cci:7://file:///Users/jacobbutler/Documents/GitHub/Kinisi/DEVELOPER_WORKFLOW.md:0:0-0:0) (PromptLayer notes)
-- [ ] Pre-PR verification: lint, test, typecheck, build
+- [x] Add unit tests asserting tracking payloads
+- [x] Ensure no real network calls in tests; registry fetch continues to fallback under blocked fetch
+- [x] Docs update in [DEVELOPER_WORKFLOW.md](DEVELOPER_WORKFLOW.md) (PromptLayer notes + append-only revisions)
+- [x] Pre-PR verification: lint, test, typecheck, build
 
 ## Stage 1: PromptLayer Client + Tracking Helper
-- Goal: Lazy client + safe non-throwing [trackPromptRun()](cci:1://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/promptlayer.ts:71:0-100:1) utility; no-ops in tests.
+- Goal: Lazy client + safe non-throwing `trackPromptRun()` utility; no-ops in tests.
 - Status: [x] Complete
 
 ## Stage 2: Instrument Assessment Generation (RAG-aware)
@@ -39,15 +41,15 @@
 
 ## Stage 4: Pass Metadata from API Routes + Test-Safe Mocks
 - Goal: Provide `userId` (and `revisionOfAssessmentId`) from API routes; ensure tests can assert calls with no network.
-- Status: [x] Complete (route wiring); [ ] Tests pending
+- Status: [x] Complete
 
 ## Stage 5: Documentation & Rollout
 - Goal: Ops notes + verify Prompt History in staging/prod.
-- Status: [ ] Not Started
+- Status: [x] Complete (docs updated; rollout verification pending platform)
 
 ## Risks & Mitigations
 - ESM/CJS interop: lazy singleton and server-only require.
-- Test flakiness: only mock [trackPromptRun](cci:1://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/promptlayer.ts:71:0-100:1); keep Prompt Registry behavior but blocked to force fallback.
+- Test flakiness: only mock [trackPromptRun](utils/promptlayer.ts); keep Prompt Registry behavior but blocked to force fallback.
 - Privacy: redaction hook ready; currently sending formatted survey only.
 - Observability drift: consistent tags (env, feature, v2) + `usedRegistry`/`ragChunksCount`.
 
@@ -64,15 +66,15 @@
 - `npm run build`
 
 ## What’s already implemented
-- [utils/promptlayerClient.ts](cci:7://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/promptlayerClient.ts:0:0-0:0) (lazy client, test/dev safe)
-- [utils/promptlayer.ts](cci:7://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/promptlayer.ts:0:0-0:0) [trackPromptRun()](cci:1://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/promptlayer.ts:71:0-100:1)
-- [utils/assessmentChain.ts](cci:7://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/assessmentChain.ts:0:0-0:0) instrumented generation & revision; added `opts.userId` & `revisionOfAssessmentId`
-- [app/api/assessment/route.ts](cci:7://file:///Users/jacobbutler/Documents/GitHub/Kinisi/app/api/assessment/route.ts:0:0-0:0) passes `userId`
-- [app/api/assessment/feedback/route.ts](cci:7://file:///Users/jacobbutler/Documents/GitHub/Kinisi/app/api/assessment/feedback/route.ts:0:0-0:0) passes `userId` & `revisionOfAssessmentId`
-- [jest.setup.js](cci:7://file:///Users/jacobbutler/Documents/GitHub/Kinisi/jest.setup.js:0:0-0:0) mocks [trackPromptRun](cci:1://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/promptlayer.ts:71:0-100:1) to a resolved no-op
+- [utils/promptlayerClient.ts](utils/promptlayerClient.ts) (lazy client, test/dev safe)
+- [utils/promptlayer.ts](utils/promptlayer.ts) `trackPromptRun()`
+- [utils/assessmentChain.ts](utils/assessmentChain.ts) instrumented generation & revision; added `opts.userId` & `revisionOfAssessmentId`
+- [app/api/assessment/route.ts](app/api/assessment/route.ts) passes `userId`
+- [app/api/assessment/feedback/route.ts](app/api/assessment/feedback/route.ts) passes `userId` & `revisionOfAssessmentId`; append-only revision semantics
+- [jest.setup.js](jest.setup.js) mocks `trackPromptRun` to a resolved no-op
 
 ## Tests to add (next step)
-- Unit: `__tests__/unit/assessmentChain.promptlayer.test.ts`
-  - Mock RAG to return `[]` and no context.
-  - Spy `RunnableSequence.from` to avoid LLM calls.
-  - Assert [trackPromptRun](cci:1://file:///Users/jacobbutler/Documents/GitHub/Kinisi/utils/promptlayer.ts:71:0-100:1) called with correct `promptName`, `tags`, and `metadata`.
+- Unit: `__tests__/unit/assessmentChain.promptlayer.test.ts` (added)
+  - Mocks RAG to return `[]` and no context.
+  - Spies `RunnableSequence.from` to avoid LLM calls.
+  - Asserts `trackPromptRun` called with correct `promptName`, `tags`, `metadata`, and validates `inputVariables.survey`.

--- a/__tests__/api/assessment.feedback.test.ts
+++ b/__tests__/api/assessment.feedback.test.ts
@@ -1,0 +1,153 @@
+import { NextRequest } from 'next/server';
+import { POST } from '../../app/api/assessment/feedback/route';
+
+jest.mock('../../utils/assessmentChain', () => ({
+  reviseAssessmentWithFeedback: jest.fn().mockResolvedValue('revised-assessment')
+}));
+
+jest.mock('../../utils/supabaseServer', () => ({
+  createSupabaseServerClient: jest.fn()
+}));
+
+const mockCreateSupabaseServerClient = require('../../utils/supabaseServer').createSupabaseServerClient;
+
+describe('/api/assessment/feedback (append-only revisions)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('inserts a new assessment row with revision_of when revising an existing assessment', async () => {
+    const mockUser = { id: 'user-1' };
+
+    const mockSupabase = {
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: mockUser }, error: null }) },
+      from: jest.fn((table: string) => {
+        if (table === 'assessments') {
+          return {
+            // When fetching the original assessment to get survey_response_id
+            select: jest.fn((cols: string) => {
+              if (cols.includes('survey_response_id')) {
+                return {
+                  eq: jest.fn(() => ({
+                    eq: jest.fn(() => ({
+                      single: jest.fn(() => Promise.resolve({
+                        data: { id: 'a-old', user_id: 'user-1', survey_response_id: 'survey-1' },
+                        error: null,
+                      }))
+                    }))
+                  }))
+                } as any;
+              }
+              // After insert, selecting id, assessment
+              return {
+                single: jest.fn(() => Promise.resolve({
+                  data: { id: 'a-new', assessment: 'revised-assessment' },
+                  error: null,
+                }))
+              } as any;
+            }),
+            insert: jest.fn(() => ({
+              select: jest.fn(() => ({
+                single: jest.fn(() => Promise.resolve({
+                  data: { id: 'a-new', assessment: 'revised-assessment' },
+                  error: null,
+                }))
+              }))
+            })),
+          } as any;
+        }
+        if (table === 'survey_responses') {
+          return {
+            select: jest.fn(() => ({
+              eq: jest.fn(() => ({
+                single: jest.fn(() => Promise.resolve({
+                  data: { id: 'survey-1', response: {} },
+                  error: null,
+                }))
+              }))
+            }))
+          } as any;
+        }
+        return {} as any;
+      }),
+    };
+
+    mockCreateSupabaseServerClient.mockResolvedValue(mockSupabase);
+
+    const request = new NextRequest('http://localhost:3000/api/assessment/feedback', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Bearer test-token',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        currentAssessment: 'old',
+        feedback: 'please revise',
+        revisionOfAssessmentId: '123e4567-e89b-12d3-a456-426614174000'
+      })
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.assessmentId).toBe('a-new');
+    expect(data.assessment).toBe('revised-assessment');
+  });
+
+  it('persists provided surveyResponses before inserting a new assessment when not revising', async () => {
+    const mockUser = { id: 'user-1' };
+
+    const insertedSurvey = { id: 'survey-2' };
+
+    const mockSupabase = {
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: mockUser }, error: null }) },
+      from: jest.fn((table: string) => {
+        if (table === 'survey_responses') {
+          return {
+            insert: jest.fn(() => ({
+              select: jest.fn(() => ({
+                single: jest.fn(() => Promise.resolve({ data: insertedSurvey, error: null }))
+              }))
+            })),
+          } as any;
+        }
+        if (table === 'assessments') {
+          return {
+            insert: jest.fn(() => ({
+              select: jest.fn(() => ({
+                single: jest.fn(() => Promise.resolve({
+                  data: { id: 'a-new', assessment: 'revised-assessment' },
+                  error: null,
+                }))
+              }))
+            })),
+          } as any;
+        }
+        return {} as any;
+      }),
+    };
+
+    mockCreateSupabaseServerClient.mockResolvedValue(mockSupabase);
+
+    const request = new NextRequest('http://localhost:3000/api/assessment/feedback', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Bearer test-token',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        currentAssessment: 'current',
+        feedback: 'new feedback',
+        surveyResponses: { goal: 'fitness' }
+      })
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.assessmentId).toBe('a-new');
+    expect(data.assessment).toBe('revised-assessment');
+  });
+});

--- a/__tests__/api/assessment.test.ts
+++ b/__tests__/api/assessment.test.ts
@@ -232,6 +232,10 @@ describe('/api/assessment', () => {
     expect(response.status).toBe(200);
     expect(data.id).toBe('assessment-1');
     expect(data.assessment).toBe('Generated assessment');
-    expect(mockGenerateAssessment).toHaveBeenCalledWith({ goal: 'fitness', experience: 'beginner' });
+    // Updated signature passes options with userId
+    expect(mockGenerateAssessment).toHaveBeenCalledWith(
+      { goal: 'fitness', experience: 'beginner' },
+      { userId: 'user-1' }
+    );
   });
 });

--- a/__tests__/unit/assessmentChain.promptlayer.test.ts
+++ b/__tests__/unit/assessmentChain.promptlayer.test.ts
@@ -1,0 +1,83 @@
+// __tests__/unit/assessmentChain.promptlayer.test.ts
+import { jest } from '@jest/globals';
+
+// Mock RAG utilities to avoid embeddings/DB/network
+jest.mock('@/utils/rag', () => ({
+  retrieveRagChunksForSurvey: jest.fn().mockResolvedValue([]),
+  formatChunksAsContext: jest.fn().mockReturnValue(''),
+}));
+
+// Mock RunnableSequence.from to prevent any LLM invocation
+jest.mock('@langchain/core/runnables', () => ({
+  RunnableSequence: {
+    from: jest.fn(() => ({ invoke: jest.fn().mockResolvedValue('ok') })),
+  },
+}));
+
+// Ensure OPENAI_API_KEY present to satisfy guards
+const OLD_ENV = process.env;
+
+describe('assessmentChain PromptLayer tracking', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV, OPENAI_API_KEY: 'test-openai-key' };
+    // Clear the global mock installed in jest.setup.js
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pl = require('@/utils/promptlayer');
+    if (pl.trackPromptRun && 'mockClear' in pl.trackPromptRun) {
+      pl.trackPromptRun.mockClear();
+    }
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    jest.clearAllMocks();
+  });
+
+  it('tracks Personalized Assessment generation with expected tags/metadata', async () => {
+    const { generateAssessmentFromSurvey } = await import('@/utils/assessmentChain');
+    // Call the function under test
+    await generateAssessmentFromSurvey({ primaryGoal: 'Strength' }, { userId: 'u1' });
+    // Read calls from the global mock installed in jest.setup.js
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pl = require('@/utils/promptlayer');
+    expect(pl.trackPromptRun).toHaveBeenCalledTimes(1);
+    const call = pl.trackPromptRun.mock.calls[0][0] as any;
+    expect(call.promptName).toBe('Personalized Assessment');
+    expect(call.tags).toEqual(expect.arrayContaining(['v2', 'assessment']));
+    expect(call.tags).toEqual(expect.arrayContaining(['dev']));
+    expect(call.metadata).toMatchObject({
+      userId: 'u1',
+      model: 'gpt-3.5-turbo',
+      temperature: 0.7,
+    });
+    expect(call.metadata.usedRegistry).toBe(false);
+    expect(call.metadata.ragChunksCount).toBe(0);
+  });
+
+  it('tracks Update Personalized Assessment revision with expected tags/metadata', async () => {
+    const { reviseAssessmentWithFeedback } = await import('@/utils/assessmentChain');
+
+    await reviseAssessmentWithFeedback({
+      currentAssessment: 'A',
+      feedback: 'F',
+      surveyResponses: {},
+      userId: 'u1',
+      revisionOfAssessmentId: '123e4567-e89b-12d3-a456-426614174000',
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pl = require('@/utils/promptlayer');
+    expect(pl.trackPromptRun).toHaveBeenCalledTimes(1);
+    const call = pl.trackPromptRun.mock.calls[0][0] as any;
+    expect(call.promptName).toBe('Update Personalized Assessment');
+    expect(call.tags).toEqual(expect.arrayContaining(['v2', 'assessment_revision']))
+    expect(call.tags).toEqual(expect.arrayContaining(['dev']));
+    expect(call.metadata).toMatchObject({
+      userId: 'u1',
+      revisionOfAssessmentId: '123e4567-e89b-12d3-a456-426614174000',
+      model: 'gpt-3.5-turbo',
+      temperature: 0.7,
+    });
+  });
+});

--- a/__tests__/unit/assessmentChain.promptlayer.test.ts
+++ b/__tests__/unit/assessmentChain.promptlayer.test.ts
@@ -44,6 +44,9 @@ describe('assessmentChain PromptLayer tracking', () => {
     expect(pl.trackPromptRun).toHaveBeenCalledTimes(1);
     const call = pl.trackPromptRun.mock.calls[0][0] as any;
     expect(call.promptName).toBe('Personalized Assessment');
+    // Assert survey inputVariables present and non-empty
+    expect(typeof call.inputVariables?.survey).toBe('string');
+    expect(call.inputVariables.survey.length).toBeGreaterThan(0);
     expect(call.tags).toEqual(expect.arrayContaining(['v2', 'assessment']));
     expect(call.tags).toEqual(expect.arrayContaining(['dev']));
     expect(call.metadata).toMatchObject({
@@ -79,5 +82,6 @@ describe('assessmentChain PromptLayer tracking', () => {
       model: 'gpt-3.5-turbo',
       temperature: 0.7,
     });
+    expect(call.metadata.usedRegistry).toBe(false);
   });
 });

--- a/__tests__/unit/utils/promptlayer.test.ts
+++ b/__tests__/unit/utils/promptlayer.test.ts
@@ -34,8 +34,8 @@ describe('fetchPromptFromRegistry', () => {
       ok: true,
       json: async () => ({
         prompt_template: {
-          messages: [
-            { prompt: { template: PROMPT_TEMPLATE } }
+          content: [
+            { type: 'text', text: PROMPT_TEMPLATE }
           ]
         }
       })
@@ -71,7 +71,7 @@ describe('fetchPromptFromRegistry', () => {
   it('throws if response is missing template content', async () => {
     (globalAny.fetch as jest.Mock).mockResolvedValue({
       ok: true,
-      json: async () => ({ prompt_template: { messages: [{}] } })
+      json: async () => ({ prompt_template: { content: [{ type: 'image', text: '' }] } })
     });
     await expect(promptlayerModule.fetchPromptFromRegistry(PROMPT_ID)).rejects.toThrow('No content found in prompt template');
   });
@@ -82,8 +82,8 @@ describe('fetchPromptFromRegistry', () => {
       ok: true,
       json: async () => ({
         prompt_template: {
-          messages: [
-            { prompt: { template: PROMPT_TEMPLATE } }
+          content: [
+            { type: 'text', text: PROMPT_TEMPLATE }
           ]
         }
       })

--- a/app/api/assessment/route.ts
+++ b/app/api/assessment/route.ts
@@ -51,7 +51,7 @@ export async function POST(req: NextRequest) {
     // Call LangChain-powered assessment generator
     let assessment: string;
     try {
-      assessment = await generateAssessmentFromSurvey(surveyResponses);
+      assessment = await generateAssessmentFromSurvey(surveyResponses, { userId: user.id });
     } catch (e: unknown) {
       console.error('[assessment] Generation failed:', e);
       return NextResponse.json({ error: 'Failed to generate assessment' }, { status: 500 });

--- a/utils/assessmentChain.ts
+++ b/utils/assessmentChain.ts
@@ -137,7 +137,7 @@ SURVEY ANSWERS:\n{{survey}}`;
   });
 
   // Use OpenAI's gpt-3.5-turbo by default; ensure API key present
-  const apiKey = process.env.OPENAI_API_KEY || process.env.NEXT_PUBLIC_OPENAI_API_KEY;
+  const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
     throw new Error("OPENAI_API_KEY is not configured on the server");
   }
@@ -156,10 +156,12 @@ SURVEY ANSWERS:\n{{survey}}`;
     new StringOutputParser()
   ]);
 
-  // Track the prompt run (non-blocking)
-  try {
+  // Track the prompt run (fire-and-forget)
+  {
     const envTag = process.env.NODE_ENV === "production" ? "prod" : "dev";
-    await trackPromptRun({
+    // Intentionally do not await
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    trackPromptRun({
       promptName: "Personalized Assessment",
       inputVariables: { survey: augmentedSurvey },
       tags: [envTag, "assessment", "v2"],
@@ -171,7 +173,7 @@ SURVEY ANSWERS:\n{{survey}}`;
         temperature,
       },
     });
-  } catch {}
+  }
 
   // Run the chain
   const assessment = await chain.invoke({ survey: augmentedSurvey });
@@ -223,7 +225,7 @@ CURRENT ASSESSMENT:\n{{assessment}}\n\nFEEDBACK:\n{{feedback}}\n\nSURVEY ANSWERS
   });
 
   // Use OpenAI's gpt-3.5-turbo by default (ensure API key)
-  const apiKey = process.env.OPENAI_API_KEY || process.env.NEXT_PUBLIC_OPENAI_API_KEY;
+  const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
     throw new Error("OPENAI_API_KEY is not configured on the server");
   }
@@ -242,21 +244,24 @@ CURRENT ASSESSMENT:\n{{assessment}}\n\nFEEDBACK:\n{{feedback}}\n\nSURVEY ANSWERS
     new StringOutputParser()
   ]);
 
-  // Track the prompt run (non-blocking)
-  try {
+  // Track the prompt run (fire-and-forget)
+  {
     const envTag = process.env.NODE_ENV === "production" ? "prod" : "dev";
-    await trackPromptRun({
+    // Intentionally do not await
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    trackPromptRun({
       promptName: "Update Personalized Assessment",
       inputVariables: { survey: surveyText },
       tags: [envTag, "assessment_revision", "v2"],
       metadata: {
         userId,
         revisionOfAssessmentId,
+        usedRegistry,
         model: modelName,
         temperature,
       },
     });
-  } catch {}
+  }
 
   // Run the chain
   const revised = await chain.invoke({

--- a/utils/promptlayerClient.ts
+++ b/utils/promptlayerClient.ts
@@ -1,0 +1,33 @@
+// utils/promptlayerClient.ts
+// Lazy PromptLayer client helper with test/dev safeguards
+
+import type { PromptLayer as PromptLayerType } from "promptlayer";
+
+let _pl: PromptLayerType | null = null;
+
+/**
+ * Returns a singleton PromptLayer client or null when disabled.
+ * Disabled when:
+ * - NODE_ENV === 'test'
+ * - process.env.DISABLE_PROMPTLAYER_TRACKING is truthy
+ * - PROMPTLAYER_API_KEY is missing
+ */
+export function getPromptLayerClient(): PromptLayerType | null {
+  try {
+    if (process.env.NODE_ENV === "test") return null;
+    if (String(process.env.DISABLE_PROMPTLAYER_TRACKING || "").toLowerCase() === "true") return null;
+
+    const apiKey = process.env.PROMPTLAYER_API_KEY;
+    if (!apiKey) return null;
+
+    if (_pl) return _pl;
+    // Note: direct import is fine in server context; this file should not be bundled into client code paths.
+    // If needed, convert to dynamic import to avoid ESM/CJS interop concerns.
+    const { PromptLayer } = require("promptlayer") as { PromptLayer: new (args: { apiKey: string }) => PromptLayerType };
+    _pl = new PromptLayer({ apiKey });
+    return _pl;
+  } catch (e) {
+    // If the SDK isn't available or any unexpected error occurs, disable tracking gracefully.
+    return null;
+  }
+}

--- a/utils/promptlayerClient.ts
+++ b/utils/promptlayerClient.ts
@@ -1,6 +1,8 @@
 // utils/promptlayerClient.ts
 // Lazy PromptLayer client helper with test/dev safeguards
 
+import 'server-only';
+
 // Avoid static imports from the 'promptlayer' package so Next.js doesn't try to
 // bundle optional peer dependencies (@anthropic-ai/sdk, @google/genai, etc.).
 // We'll dynamically require the module at runtime on the server only.
@@ -17,23 +19,41 @@ let _pl: PromptLayerClient = null;
  * Returns a singleton PromptLayer client or null when disabled.
  * Disabled when:
  * - NODE_ENV === 'test'
- * - process.env.DISABLE_PROMPTLAYER_TRACKING is truthy
+ * - DISABLE_PROMPTLAYER_TRACKING is set to a truthy value ('true'|'1'|'yes'|'on', case-insensitive)
  * - PROMPTLAYER_API_KEY is missing
  */
 export function getPromptLayerClient(): PromptLayerClient {
   try {
-    if (process.env.NODE_ENV === "test") return null;
-    if (String(process.env.DISABLE_PROMPTLAYER_TRACKING || "").toLowerCase() === "true") return null;
+    if (process.env.NODE_ENV === "test") {
+      // eslint-disable-next-line no-console
+      console.debug('[PromptLayer] disabled: test environment');
+      return null;
+    }
+    const disable = String(process.env.DISABLE_PROMPTLAYER_TRACKING || "").toLowerCase();
+    if (["true","1","yes","on"].includes(disable)) {
+      if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.debug('[PromptLayer] disabled via DISABLE_PROMPTLAYER_TRACKING');
+      }
+      return null;
+    }
 
     const apiKey = process.env.PROMPTLAYER_API_KEY;
-    if (!apiKey) return null;
+    if (!apiKey) {
+      if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.debug('[PromptLayer] disabled: PROMPTLAYER_API_KEY missing');
+      }
+      return null;
+    }
 
     if (_pl) return _pl;
     // Use eval('require') to prevent bundlers from resolving 'promptlayer' at build time
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const req: any = eval('require');
-    const { PromptLayer } = req("promptlayer");
-    _pl = new PromptLayer({ apiKey });
+    const mod = req("promptlayer");
+    const PromptLayerCtor = (mod as any).PromptLayer ?? (mod as any).default;
+    _pl = new PromptLayerCtor({ apiKey });
     return _pl;
   } catch (e) {
     // If the SDK isn't available or any unexpected error occurs, disable tracking gracefully.

--- a/utils/promptlayerClient.ts
+++ b/utils/promptlayerClient.ts
@@ -1,9 +1,17 @@
 // utils/promptlayerClient.ts
 // Lazy PromptLayer client helper with test/dev safeguards
 
-import type { PromptLayer as PromptLayerType } from "promptlayer";
+// Avoid static imports from the 'promptlayer' package so Next.js doesn't try to
+// bundle optional peer dependencies (@anthropic-ai/sdk, @google/genai, etc.).
+// We'll dynamically require the module at runtime on the server only.
 
-let _pl: PromptLayerType | null = null;
+type PromptLayerClient = {
+  // Minimal surface we use; keep as any to avoid pulling in types
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  run: (args: any) => Promise<any>;
+} | null;
+
+let _pl: PromptLayerClient = null;
 
 /**
  * Returns a singleton PromptLayer client or null when disabled.
@@ -12,7 +20,7 @@ let _pl: PromptLayerType | null = null;
  * - process.env.DISABLE_PROMPTLAYER_TRACKING is truthy
  * - PROMPTLAYER_API_KEY is missing
  */
-export function getPromptLayerClient(): PromptLayerType | null {
+export function getPromptLayerClient(): PromptLayerClient {
   try {
     if (process.env.NODE_ENV === "test") return null;
     if (String(process.env.DISABLE_PROMPTLAYER_TRACKING || "").toLowerCase() === "true") return null;
@@ -21,9 +29,10 @@ export function getPromptLayerClient(): PromptLayerType | null {
     if (!apiKey) return null;
 
     if (_pl) return _pl;
-    // Note: direct import is fine in server context; this file should not be bundled into client code paths.
-    // If needed, convert to dynamic import to avoid ESM/CJS interop concerns.
-    const { PromptLayer } = require("promptlayer") as { PromptLayer: new (args: { apiKey: string }) => PromptLayerType };
+    // Use eval('require') to prevent bundlers from resolving 'promptlayer' at build time
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const req: any = eval('require');
+    const { PromptLayer } = req("promptlayer");
     _pl = new PromptLayer({ apiKey });
     return _pl;
   } catch (e) {


### PR DESCRIPTION
- **feat: Secure registration with access code**
- **fix: Update pnpm-lock.yaml**
- **fix: Handle undefined supabaseAdmin client**
- **feat(register): harden /api/register runtime + Resend; pin engines & packageManager; sync deps**
- **chore(registration): harden API, client, CI; enforce engines; docs\n\n- app/api/register/route.ts: server-only guard, per-IP rate limit, sanitized errors, EMAIL_FROM for Resend, no user in response, redirectTo /survey\n- app/register/page.tsx: wrap fetch in try/catch/finally\n- .github/workflows/ci.yml: switch to pnpm@10.15.0, guard Codecov upload, add build step\n- .npmrc: engine-strict=true\n- README.md: add env var section for secure registration & email\n- remove middleware.ts and package-lock.json**
- **Fix RLS 404 on Program page via server-side Supabase client; add auth redirect; RLS-authenticated approve API; make getLatestAssessment robust to maybeSingle()/single(); all tests green**
- **CI: fix Codecov step to use secrets-based condition and with.token; do not fail CI on upload errors**
- **test: add ProgramActions component test and schedule feedback API tests; e2e: program schedule flow; chore: ensure async params on dynamic routes**
- **ci: set up pnpm before setup-node cache to avoid pnpm missing**
- **fix(api): avoid importing browser supabase client in server beta-request helpers; require explicit Supabase client**
- **chore(api): add force-dynamic to program API routes to prevent static prerendering with Supabase server client**
- **chore(api): add force-dynamic to assessment, exercises, and start-date routes to prevent static prerendering**
- **ci: use Supabase secrets for Next.js build env in CI**
- **chore(ci): codecov secrets usage; api: force-dynamic for RAG; tests: fix TS 'never' errors in schedule API tests; docs: Netlify + CI env details; readme: align deployment**
- **fix(api): harden assessment and program routes; tighten validation and error handling; remove client userId (#135)**
- **API hardening: sanitize error responses, tighten types, and fix lint across routes and ProgramCalendar (CodeRabbit #135). Typecheck/lint/tests all pass locally.**
- **docs: update README, PRD, and project docs for Next.js 15, security hardening, and current architecture**
- **chore(ui): centralize gradients via design tokens + btn utilities\n\n- Add brand gradient + focus ring tokens in app/globals.css\n- Add/standardize .btn-primary and .btn-secondary utilities\n- Replace hard-coded/btn-gradient usages across pages/components\n- Tokenize progress bar gradient to use brand stops\n- Preserve semantic green/indigo buttons as-is\n\nNo functional changes; styling refactor only. Tests unaffected.**
- **build: add baseUrl to tsconfig.json to resolve '@/…' alias in Next.js build**
- **fix: resolve dashboard integration test failures and syntax errors**
- **fix: resolve CI build errors from module resolution issues**
- **fix: resolve build errors and module resolution issues**
- **fix: resolve remaining CI build errors**
- **fix: remove v2-documentation directory causing CI build conflicts**
- **fix: resolve onboarding UX issues and API errors**
- **fix(auth): eliminate hydration mismatches on auth pages and auto sign-in after email confirm; fix assessment 404 by persisting survey server-side**
- **test: stabilize onboarding flow and auth/dashboard tests**
- **fix(vercel): wrap ProtectedRoute with Suspense and add v2 providers in (dashboard)/layout to fix prerender errors**
- **fix(vercel): convert (dashboard)/layout back to server component and wrap with client providers to avoid ENOENT manifest error**
- **fix: upgrade axios to 1.12.1 for security vulnerability and convert (dashboard)/page.tsx to server component with redirect**
- **fix: remove duplicate dashboard route causing ENOENT build error**
- **fix: use middleware for dashboard redirect to resolve ENOENT build error**
- **fix: complete route group rename from (dashboard) to dashboard-v2**
- **feat(promptlayer): add Prompt History tracking with tags/metadata; instrument assessment generation & revision; tests & jest polyfills; fix auth order in feedback API**
- **fix(vercel): avoid bundling PromptLayer optional deps by dynamic runtime require; unblock Next.js build**
- **feat(promptlayer,assessment): add fetch timeout and content parsing; server-only guards; fire-and-forget tracking; OPENAI_API_KEY-only; append-only assessment revisions; persist provided survey responses; tests + docs (Issue #166)**
